### PR TITLE
remove unused dep that was stopping building

### DIFF
--- a/src/client/component/MosaicPanel.jsx
+++ b/src/client/component/MosaicPanel.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Toggle from './Toggle.jsx';
-import FlipMove from 'react-flip-move';
 import Tile from './Tile.jsx';
 
 var Masonry = require('react-masonry-component');


### PR DESCRIPTION
Are you still using this? Since it's not in package.json, it doesn't install automatically, meaning you get a build error in webpack. Either it should be added to package.json or removed from MosiacPanel.jsx :)
